### PR TITLE
feat: Removes hardcoded adoc settings

### DIFF
--- a/src/openapi_to_asciidoc/templates/openapi_obj.j2
+++ b/src/openapi_to_asciidoc/templates/openapi_obj.j2
@@ -1,8 +1,4 @@
 {%import 'util.j2' as utils%}
-:sectnums:
-:sectnumlevels: 4
-:toc:
-:toclevels: 3
 
 = Open API specification
 


### PR DESCRIPTION
There are some hardcoded asciidoc settings in one of the templates, which makes it hard for anyone using this to actually set those for themselves. This PR removes that default. 